### PR TITLE
Fix nrf section iter ARMCC compiler macro check

### DIFF
--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/experimental_section_vars/nrf_section_iter.c
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/experimental_section_vars/nrf_section_iter.c
@@ -45,7 +45,7 @@
 #include "nrf_section_iter.h"
 
 
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__CC_ARM)
 static void nrf_section_iter_item_set(nrf_section_iter_t * p_iter)
 {
     ASSERT(p_iter            != NULL);
@@ -82,7 +82,7 @@ void nrf_section_iter_init(nrf_section_iter_t * p_iter, nrf_section_set_t const 
 
     p_iter->p_set = p_set;
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
     p_iter->p_item = p_iter->p_set->section.p_start;
     if (p_iter->p_item == p_iter->p_set->section.p_end)
     {
@@ -106,7 +106,7 @@ void nrf_section_iter_next(nrf_section_iter_t * p_iter)
 
     p_iter->p_item = (void *)((size_t)(p_iter->p_item) + p_iter->p_set->item_size);
 
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
     if (p_iter->p_item == p_iter->p_set->section.p_end)
     {
         p_iter->p_item = NULL;

--- a/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/experimental_section_vars/nrf_section_iter.h
+++ b/targets/TARGET_NORDIC/TARGET_NRF5x/TARGET_SDK_15_0/components/libraries/experimental_section_vars/nrf_section_iter.h
@@ -68,7 +68,7 @@ typedef struct
 /**@brief Set of the sections description structure. */
 typedef struct
 {
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
     nrf_section_t           section;    //!< Description of the set of sections.
                                         /**<
                                          * In case of GCC all sections in the set are sorted and
@@ -87,7 +87,7 @@ typedef struct
 typedef struct
 {
     nrf_section_set_t const * p_set;        //!< Pointer to the appropriate section set.
-#if !defined(__GNUC__)
+#if !defined(__GNUC__) || defined(__CC_ARM)
     nrf_section_t const     * p_section;    //!< Pointer to the selected section.
                                             /**<
                                              * In case of GCC all sections in the set are sorted and
@@ -110,7 +110,7 @@ typedef struct
  * @param[in]   _count  Number of the sections in the set. This parameter is ignored in case of GCC.
  * @hideinitializer
  */
-#if defined(__GNUC__)
+#if defined(__GNUC__) && !defined(__CC_ARM)
 
 #define NRF_SECTION_SET_DEF(_name, _type, _count)                                                   \
                                                                                                     \


### PR DESCRIPTION
### Description

<!-- 
    Required
    Add here detailed changes summary, testing results, dependencies 
    Good example: https://os.mbed.com/docs/latest/reference/workflow.html (Pull request template)
-->

Because mbed-cli uses `--gnu` as one of the compiler options, so we need to ckeck both `__GNUC__` and `__CC_ARM` when using ARMCC compiler.

### Pull request type

<!-- 
    Required
    Please add only one X to one of the following types. Do not fill multiple types (split the pull request otherwise).
    Please note this is not a GitHub task list, indenting the boxes or changing the format to add a '.' or '*' in front
    of them would change the meaning incorrectly. The only changes to be made are to add a description text under the
    description heading and to add a 'x' to the correct box.
-->
    [x] Fix
    [ ] Refactor
    [ ] Target update
    [ ] Functionality change
    [ ] Docs update
    [ ] Test update
    [ ] Breaking change

